### PR TITLE
Clean Urls & Css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,10 @@
-const gulp = require("gulp");
-const pug = require("gulp-pug");
-const babel = require("gulp-babel");
-const sass = require("gulp-sass")(require("node-sass"));
-const imagemin = require("gulp-imagemin");
+const gulp = require("gulp"),
+  pug = require("gulp-pug"),
+  babel = require("gulp-babel"),
+  purge = require("gulp-css-purge"),
+  sass = require("gulp-sass")(require("node-sass")),
+  cleanCSS = require("gulp-clean-css"),
+  imagemin = require("gulp-imagemin");
 
 const {
   VIEWS_DIR,
@@ -58,6 +60,8 @@ gulp.task("sass", () => {
   return gulp
     .src([base + "/*.scss", base + "/**/*.scss"])
     .pipe(sass({ outputStyle: "compressed" }).on("error", sass.logError))
+    .pipe(purge({ verbose: false, shorten: true }))
+    .pipe(cleanCSS())
     .pipe(gulp.dest(DIST_DIR + "/css"));
 });
 
@@ -83,8 +87,12 @@ gulp.task("default", async () => {
   server.init({
     server: {
       baseDir: DIST_DIR,
+      serveStaticOptions: {
+        extensions: ["html"],
+      },
     },
     ghostMode: false,
+    notify: false,
   });
 
   gulp.watch(VIEWS_DIR, gulp.series("views")).on("change", server.reload);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "cloudinary": "^1.26.3",
     "gray-matter": "^4.0.3",
     "gulp": "^4.0.2",
+    "gulp-clean-css": "^4.3.0",
+    "gulp-css-purge": "^3.0.9",
     "gulp-imagemin": "^7.1.0",
     "gulp-pug": "^5.0.0",
     "gulp-sass": "^5.0.0",

--- a/scripts/create-one-page-per-furniture.js
+++ b/scripts/create-one-page-per-furniture.js
@@ -55,7 +55,7 @@ const fetchMarkdown = async () => {
       title: data.title,
       description: data.description,
       image: data.image,
-      link: "/furnitures/" + fileName.replace(".pug", ".html"),
+      link: "/furnitures/" + fileName.replace(".pug", ""),
     });
     console.log("✅ Created file " + fileName);
     fs.writeFileSync(pagePugDir, pugTemplate, { encoding: "utf-8" });

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -14,6 +14,7 @@
   touch-action: none;
 
   &__box {
+    display: block;
     position: relative;
     overflow: hidden;
     min-width: 100%;

--- a/src/views/components/navegation.pug
+++ b/src/views/components/navegation.pug
@@ -2,5 +2,5 @@ nav.main-nav
     .container 
         ul.list
             li.list__item: a.list__link(href="/") Inicio
-            li.list__item: a.list__link(href="/about.html") Quienes Somos?
-            li.list__item: a.list__link(href="/galery.html") Galería de Fotos
+            li.list__item: a.list__link(href="/about") Quienes Somos?
+            li.list__item: a.list__link(href="/galery") Galería de Fotos

--- a/src/views/pages/index.pug
+++ b/src/views/pages/index.pug
@@ -29,7 +29,7 @@ block content
                     h1(translate="no") Estilos & Diseños WEM
                     p Los mejores muebles de Melamine
             each item in main_data
-                .presentation__box 
+                a.presentation__box(href="/furnitures/muebles-para-"+item.title.toLowerCase())
                     img.presentation__image(data-src=item.image,alt=item.title,loading="lazy")
                     h2.presentation__title Fabricamos 
                         span.presentation__title-block Muebles para #{item.title}
@@ -43,7 +43,7 @@ block content
         .works__box
             .works-grid
                 +worksGalery()
-            a.works__button(href="/galery.html") Ver más
+            a.works__button(href="/galery") Ver más
 
 block scripts 
     script(src="/js/index.js") 


### PR DESCRIPTION
- Las urls ya no tienen la extensión `.html` .
- Añadí `gulp-css-purge` para tener la hoja de estilos más limpia, así como también añadí `gulp-clean-css` para la compatibilidad .
